### PR TITLE
fixed a reset reponse when there is no valid parallel-index, still return 200

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "endpoint-response-override",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The module will override an endpoint response, it is used in the integration tests for express server application",
   "main": "index.js",
   "scripts": {

--- a/src/endpoint-response-override.js
+++ b/src/endpoint-response-override.js
@@ -38,7 +38,7 @@ overrideRouter.post('/reset', (req, res, next) => {
         endpointsOverride[parallelIndex] = [];
         res.status(200).jsonp({message: 'Reset Endpoints Success'});
     };
-    res.status(500).jsonp({message: 'Reset Failed, invalid x-parallel-index'});
+    return res.status(200).jsonp({message: 'Reset skipped, invalid x-parallel-index'});
 });
 
 module.exports = {


### PR DESCRIPTION
fixed a reset reponse when there is no valid parallel-index, still return 200